### PR TITLE
Add platform builder scaffolding tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# 2agent
+# 2agent Platform Builder
+
+This repository provides a minimal "platform for creating platforms". Use the
+`platform_builder` package to capture a platform idea as a blueprint, write it
+to disk, and scaffold a starter folder structure with service stubs.
+
+## Features
+- Blueprint model for platform metadata, features, and services
+- Scaffolder that creates README files and service directories
+- Lightweight CLI to create and scaffold blueprints (no external dependencies)
+
+## Usage
+Create a blueprint JSON file:
+
+```bash
+python -m platform_builder.cli create \
+  --name "Data Hub" \
+  --description "Platform for data products" \
+  --feature "ingestion" --feature "governance" \
+  --service "api:REST interface" --service "ui:Admin console" \
+  --output blueprint.json
+```
+
+Scaffold a platform directory from the saved blueprint:
+
+```bash
+python -m platform_builder.cli scaffold blueprint.json --output data-hub
+```
+
+The scaffold includes a root `README.md`, the `blueprint.json`, and per-service
+folders with their own `README.md` placeholders.
+
+## Development
+Run the test suite with the built-in `unittest` runner:
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py'
+```

--- a/platform_builder/__init__.py
+++ b/platform_builder/__init__.py
@@ -1,0 +1,7 @@
+"""Platform builder package for scaffolding new platforms."""
+
+from .blueprint import PlatformBlueprint
+from .scaffolder import PlatformScaffolder
+from .cli import main
+
+__all__ = ["PlatformBlueprint", "PlatformScaffolder", "main"]

--- a/platform_builder/blueprint.py
+++ b/platform_builder/blueprint.py
@@ -1,0 +1,77 @@
+"""Blueprint model for describing new platforms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class PlatformBlueprint:
+    """In-memory description of a platform configuration.
+
+    A blueprint captures the essential information required to scaffold
+    a new platform: its name, a short description, the features it should
+    offer, and the services that power it.
+    """
+
+    name: str
+    description: str
+    features: List[str] = field(default_factory=list)
+    services: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.name = self.name.strip()
+        self.description = self.description.strip()
+        if not self.name:
+            raise ValueError("Platform name cannot be empty.")
+        if not self.description:
+            raise ValueError("Platform description cannot be empty.")
+        self.features = [feature.strip() for feature in self.features if feature.strip()]
+        self.services = {k.strip(): v.strip() for k, v in self.services.items() if k.strip()}
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a serialisable dictionary representation."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "features": list(self.features),
+            "services": dict(self.services),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "PlatformBlueprint":
+        """Create a blueprint from a mapping."""
+        name = str(data.get("name", "")).strip()
+        description = str(data.get("description", "")).strip()
+        features_raw = data.get("features")
+        services_raw = data.get("services")
+
+        features: List[str]
+        if isinstance(features_raw, list):
+            features = [str(item) for item in features_raw]
+        elif features_raw is None:
+            features = []
+        else:
+            raise TypeError("features must be a list of strings")
+
+        services: Dict[str, str]
+        if isinstance(services_raw, dict):
+            services = {str(k): str(v) for k, v in services_raw.items()}
+        elif services_raw is None:
+            services = {}
+        else:
+            raise TypeError("services must be a mapping of service name to summary")
+
+        return cls(name=name, description=description, features=features, services=services)
+
+    def summary(self) -> str:
+        """Return a human-friendly summary of the blueprint."""
+        lines = [f"Platform: {self.name}", f"Description: {self.description}"]
+        if self.features:
+            lines.append("Features:")
+            lines.extend([f"- {feature}" for feature in self.features])
+        if self.services:
+            lines.append("Services:")
+            lines.extend([f"- {name}: {details}" for name, details in self.services.items()])
+        return "\n".join(lines)

--- a/platform_builder/cli.py
+++ b/platform_builder/cli.py
@@ -1,0 +1,86 @@
+"""Command-line interface for the platform builder."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from .blueprint import PlatformBlueprint
+from .scaffolder import PlatformScaffolder
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create and scaffold platform blueprints.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = subparsers.add_parser("create", help="Create a blueprint JSON file")
+    create_parser.add_argument("--name", required=True, help="Platform name")
+    create_parser.add_argument("--description", required=True, help="Platform description")
+    create_parser.add_argument("--feature", action="append", default=[], help="Feature to include")
+    create_parser.add_argument(
+        "--service",
+        action="append",
+        default=[],
+        help="Service definition as name:details (e.g., api:'REST endpoints')",
+    )
+    create_parser.add_argument("--output", type=Path, default=Path("blueprint.json"), help="Output file")
+
+    scaffold_parser = subparsers.add_parser("scaffold", help="Scaffold a platform from an existing blueprint")
+    scaffold_parser.add_argument("blueprint", type=Path, help="Path to blueprint JSON")
+    scaffold_parser.add_argument("--output", type=Path, default=Path("platform"), help="Target directory")
+
+    return parser
+
+
+def parse_services(service_args: List[str]) -> dict[str, str]:
+    services: dict[str, str] = {}
+    for raw in service_args:
+        name, _, details = raw.partition(":")
+        name = name.strip()
+        details = details.strip(" \"")
+        if not name:
+            raise ValueError("Service entries must include a name before the colon")
+        services[name] = details or ""
+    return services
+
+
+def handle_create(args: argparse.Namespace) -> Path:
+    blueprint = PlatformBlueprint(
+        name=args.name,
+        description=args.description,
+        features=args.feature,
+        services=parse_services(args.service),
+    )
+    scaffolder = PlatformScaffolder(blueprint)
+    return scaffolder.write_blueprint(args.output)
+
+
+def handle_scaffold(args: argparse.Namespace) -> list[Path]:
+    data = json.loads(args.blueprint.read_text(encoding="utf-8"))
+    blueprint = PlatformBlueprint.from_dict(data)
+    scaffolder = PlatformScaffolder(blueprint)
+    return list(scaffolder.scaffold(args.output))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "create":
+        output = handle_create(args)
+        print(f"Blueprint written to {output}")
+        return 0
+
+    if args.command == "scaffold":
+        created = handle_scaffold(args)
+        print(f"Created {len(created)} paths under {args.output}")
+        return 0
+
+    parser.error("Unknown command")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/platform_builder/scaffolder.py
+++ b/platform_builder/scaffolder.py
@@ -1,0 +1,77 @@
+"""Utilities for turning a blueprint into a working folder."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+from .blueprint import PlatformBlueprint
+
+
+class PlatformScaffolder:
+    """Create files and directories based on a PlatformBlueprint."""
+
+    def __init__(self, blueprint: PlatformBlueprint) -> None:
+        self.blueprint = blueprint
+
+    def write_blueprint(self, path: Path) -> Path:
+        """Persist the blueprint to a JSON file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.blueprint.to_dict(), indent=2), encoding="utf-8")
+        return path
+
+    def scaffold(self, target_dir: Path) -> Iterable[Path]:
+        """Create a directory structure for the blueprint.
+
+        Returns an iterable of created paths.
+        """
+        created: list[Path] = []
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        readme_path = target_dir / "README.md"
+        readme_path.write_text(self._render_readme(), encoding="utf-8")
+        created.append(readme_path)
+
+        blueprint_path = target_dir / "blueprint.json"
+        self.write_blueprint(blueprint_path)
+        created.append(blueprint_path)
+
+        services_dir = target_dir / "services"
+        services_dir.mkdir(exist_ok=True)
+        created.append(services_dir)
+
+        for service, description in self.blueprint.services.items():
+            service_dir = services_dir / _safe_slug(service)
+            service_dir.mkdir(exist_ok=True)
+            created.append(service_dir)
+            service_readme = service_dir / "README.md"
+            service_readme.write_text(
+                f"# {service}\n\n{description or 'Service details pending.'}\n",
+                encoding="utf-8",
+            )
+            created.append(service_readme)
+
+        return created
+
+    def _render_readme(self) -> str:
+        """Render the root README for the scaffolded platform."""
+        header = f"# {self.blueprint.name}\n\n{self.blueprint.description}\n"
+        features_section = self._render_list_section("Features", self.blueprint.features)
+        services_section = self._render_list_section("Services", self.blueprint.services.keys())
+        return "\n\n".join(filter(None, [header, features_section, services_section])) + "\n"
+
+    @staticmethod
+    def _render_list_section(title: str, items: Iterable[str]) -> str:
+        items = list(items)
+        if not items:
+            return ""
+        bullet_lines = "\n".join(f"- {item}" for item in items)
+        return f"## {title}\n\n{bullet_lines}"
+
+
+def _safe_slug(value: str) -> str:
+    """Return a filesystem-safe slug for a service name."""
+    value = value.strip().lower().replace(" ", "-")
+    return "".join(ch for ch in value if ch.isalnum() or ch in {"-", "_"}) or "service"

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+
+from platform_builder.blueprint import PlatformBlueprint
+
+
+class PlatformBlueprintTests(unittest.TestCase):
+    def test_to_and_from_dict_round_trip(self):
+        blueprint = PlatformBlueprint(
+            name="Creator",
+            description="Helps build other platforms",
+            features=["scaffolding", "templates"],
+            services={"api": "REST endpoints", "ui": "Admin console"},
+        )
+
+        as_dict = blueprint.to_dict()
+        restored = PlatformBlueprint.from_dict(as_dict)
+
+        self.assertEqual(restored.name, blueprint.name)
+        self.assertEqual(restored.description, blueprint.description)
+        self.assertEqual(restored.features, blueprint.features)
+        self.assertEqual(restored.services, blueprint.services)
+
+    def test_rejects_empty_name(self):
+        with self.assertRaises(ValueError):
+            PlatformBlueprint(name="   ", description="desc")
+
+    def test_rejects_empty_description(self):
+        with self.assertRaises(ValueError):
+            PlatformBlueprint(name="Platform", description=" ")
+
+    def test_summary_contains_sections(self):
+        blueprint = PlatformBlueprint(
+            name="Generator",
+            description="Generates projects",
+            features=["cli"],
+            services={"api": "API layer"},
+        )
+        summary = blueprint.summary()
+        self.assertIn("Platform: Generator", summary)
+        self.assertIn("Features:", summary)
+        self.assertIn("Services:", summary)
+
+    def test_from_dict_validates_types(self):
+        with self.assertRaises(TypeError):
+            PlatformBlueprint.from_dict({"name": "P", "description": "d", "features": "wrong"})
+        with self.assertRaises(TypeError):
+            PlatformBlueprint.from_dict({"name": "P", "description": "d", "services": []})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -1,0 +1,48 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from platform_builder.blueprint import PlatformBlueprint
+from platform_builder.scaffolder import PlatformScaffolder, _safe_slug
+
+
+class PlatformScaffolderTests(unittest.TestCase):
+    def setUp(self):
+        self.blueprint = PlatformBlueprint(
+            name="Maker",
+            description="Builds other platforms",
+            features=["cli", "modules"],
+            services={"API": "JSON endpoints"},
+        )
+        self.scaffolder = PlatformScaffolder(self.blueprint)
+
+    def test_write_blueprint_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "blueprint.json"
+            result = self.scaffolder.write_blueprint(output)
+            self.assertTrue(result.exists())
+            data = json.loads(result.read_text(encoding="utf-8"))
+            self.assertEqual(data["name"], self.blueprint.name)
+
+    def test_scaffold_creates_expected_structure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "platform"
+            created = list(self.scaffolder.scaffold(target))
+            expected_files = {
+                target / "README.md",
+                target / "blueprint.json",
+                target / "services",
+                target / "services" / "api",
+                target / "services" / "api" / "README.md",
+            }
+            self.assertTrue(expected_files.issubset(set(created)))
+            self.assertIn("Maker", (target / "README.md").read_text(encoding="utf-8"))
+
+    def test_safe_slug_handles_empty(self):
+        self.assertEqual(_safe_slug("   "), "service")
+        self.assertEqual(_safe_slug("API Layer"), "api-layer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add PlatformBlueprint model with validation and summaries
- provide scaffolder and CLI to write and scaffold platform blueprints
- document usage and include unit tests

## Testing
- python -m unittest discover -s tests -p 'test_*.py'

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d59c2cc0832781a8b1f125660f54)