### PR TITLE
Expand conversation platform capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # 2agent
+
+A minimal two-agent conversation platform. Agents are simple callables that receive a prompt and the full conversation history,
+making it easy to script deterministic interactions or prototypes without external dependencies.
+
+## Features
+- Register lightweight agents implemented as Python callables.
+- Send a message from one agent to another and automatically capture replies.
+- Broadcast a prompt to all agents for quick fan-out behaviors.
+- Inspect immutable conversation history for debugging or further processing.
+- Run longer, alternating multi-turn dialogues with a built-in coordinator.
+
+## Quickstart
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m unittest discover -s tests
+```
+
+### Basic usage
+```python
+from agent_platform import Agent, Conversation, ConversationCoordinator
+
+def echo_handler(prompt, history):
+    return f"echo: {prompt} (seen {len(history)} messages)"
+
+def respond_all_caps(prompt, _history):
+    return prompt.upper()
+
+conversation = Conversation()
+conversation.add_agent(Agent("alpha", echo_handler))
+conversation.add_agent(Agent("beta", respond_all_caps))
+
+reply = conversation.send("alpha", "beta", "hello")
+print(reply)  # outputs: HELLO
+print(conversation.history)
+```
+
+### Multi-turn coordination
+```python
+conversation = Conversation()
+conversation.add_agent(Agent("alpha", echo_handler))
+conversation.add_agent(Agent("beta", respond_all_caps))
+
+coordinator = ConversationCoordinator(conversation)
+coordinator.run_dialogue("alpha", "beta", "start", max_turns=5)
+for message in conversation.history:
+    print(message)
+```
+
+### Broadcast to multiple agents
+```python
+gamma = Agent("gamma", lambda prompt, history: f"saw {prompt} after {len(history)} entries")
+conversation.add_agent(gamma)
+all_replies = conversation.broadcast("alpha", "status check")
+for reply in all_replies:
+    print(reply)
+```
+
+## Running tests
+The repository uses Python's built-in `unittest` module to avoid extra dependencies. Execute the full test suite with:
+
+```bash
+python -m unittest discover -s tests
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # 2agent
 
 A minimal two-agent conversation platform. Agents are simple callables that receive a prompt and the full conversation history,
-making it easy to script deterministic interactions or prototypes without external dependencies.
+making it easy to script deterministic interactions or prototypes without external dependencies. A lightweight text UI (CLI)
+is included so you can experiment with the platform without writing code.
 
 ## Features
 - Register lightweight agents implemented as Python callables.
@@ -56,6 +57,35 @@ conversation.add_agent(gamma)
 all_replies = conversation.broadcast("alpha", "status check")
 for reply in all_replies:
     print(reply)
+```
+
+### CLI text UI
+
+Run the platform without writing code using the built-in CLI. It ships with a handful of ready-to-use agents: `echo`, `uppercase`,
+`reverse`, and `counter`.
+
+Launch the interactive REPL:
+
+```bash
+python -m agent_platform repl
+```
+
+Send a single message between default agents and view the rendered history:
+
+```bash
+python -m agent_platform send echo uppercase "hello world"
+```
+
+Broadcast a status update from the `counter` agent to all others:
+
+```bash
+python -m agent_platform broadcast counter "status check"
+```
+
+Run an alternating dialogue for a few turns:
+
+```bash
+python -m agent_platform dialogue echo reverse "keep going" --turns 4
 ```
 
 ## Running tests

--- a/agent_platform/__init__.py
+++ b/agent_platform/__init__.py
@@ -1,0 +1,8 @@
+"""Simple two-agent conversation platform."""
+
+from .agent import Agent
+from .conversation import Conversation
+from .coordinator import ConversationCoordinator
+from .messages import Message
+
+__all__ = ["Agent", "Conversation", "ConversationCoordinator", "Message"]

--- a/agent_platform/__main__.py
+++ b/agent_platform/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point for ``python -m agent_platform``."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/agent_platform/agent.py
+++ b/agent_platform/agent.py
@@ -1,0 +1,19 @@
+from typing import Callable, Iterable, List
+
+from .messages import Message
+
+
+class Agent:
+    """Simple agent wrapper around a callable handler."""
+
+    def __init__(self, name: str, handler: Callable[[str, Iterable[Message]], str]):
+        if not name:
+            raise ValueError("Agent name must be a non-empty string")
+        self.name = name
+        self._handler = handler
+
+    def respond(self, prompt: str, history: List[Message]) -> str:
+        reply = self._handler(prompt, history)
+        if not isinstance(reply, str):
+            raise TypeError("Agent handlers must return string responses")
+        return reply

--- a/agent_platform/cli.py
+++ b/agent_platform/cli.py
@@ -1,0 +1,186 @@
+"""Text-first CLI for interacting with the conversation platform.
+
+The CLI keeps dependencies minimal and relies only on the Python standard
+library. It offers both single-command execution via ``argparse`` and an
+interactive REPL with a lightweight text UI to inspect message history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from typing import Iterable, List, Sequence
+
+from .agent import Agent
+from .conversation import Conversation
+from .coordinator import ConversationCoordinator
+from .messages import Message
+
+
+def build_default_conversation() -> Conversation:
+    """Create a conversation preloaded with a few useful agents."""
+
+    conversation = Conversation()
+
+    conversation.add_agent(
+        Agent("echo", lambda prompt, history: f"echo: {prompt} (seen {len(history)} messages)")
+    )
+    conversation.add_agent(Agent("uppercase", lambda prompt, _history: prompt.upper()))
+    conversation.add_agent(Agent("reverse", lambda prompt, _history: prompt[::-1]))
+
+    def counting_handler():
+        counter = 0
+
+        def _handler(prompt: str, _history: List[Message]) -> str:
+            nonlocal counter
+            counter += 1
+            return f"#{counter}: {prompt}"
+
+        return _handler
+
+    conversation.add_agent(Agent("counter", counting_handler()))
+    return conversation
+
+
+def render_history(history: Iterable[Message]) -> str:
+    """Return a compact text table summarizing the conversation history."""
+
+    rows = list(history)
+    if not rows:
+        return "No messages yet. Use send, broadcast, or dialogue to create activity."
+
+    header = f"{'Time (UTC)':10} | {'Route':22} | Content"
+    divider = "-" * len(header)
+    output = [header, divider]
+
+    for message in rows:
+        receiver = message.receiver or "broadcast"
+        route = f"{message.sender} -> {receiver}"
+        timestamp = message.timestamp.strftime("%H:%M:%S")
+        output.append(f"{timestamp:10} | {route:22} | {message.content}")
+
+    return "\n".join(output)
+
+
+def _start_repl(conversation: Conversation) -> None:
+    print("Type 'help' for commands, 'exit' to quit. Built-in agents: echo, uppercase, reverse, counter.")
+    coordinator = ConversationCoordinator(conversation)
+
+    while True:
+        try:
+            raw = input("2agent> ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            break
+
+        if not raw:
+            continue
+
+        if raw.lower() in {"exit", "quit"}:
+            break
+
+        if raw.lower() == "help":
+            print(
+                "Available commands:\n"
+                "  send <sender> <receiver> <message>   - send message between agents\n"
+                "  broadcast <sender> <message>         - send to all other agents\n"
+                "  dialogue <starter> <responder> <prompt> [turns] - run alternating exchange\n"
+                "  history                              - show message table\n"
+                "  clear                                - clear history\n"
+                "  agents                               - list registered agents\n"
+                "  exit | quit                          - leave the REPL"
+            )
+            continue
+
+        parts = shlex.split(raw)
+        command, *args = parts
+
+        try:
+            if command == "send" and len(args) >= 3:
+                sender, receiver, message = args[0], args[1], " ".join(args[2:])
+                conversation.send(sender, receiver, message)
+                print(render_history(conversation.history))
+            elif command == "broadcast" and len(args) >= 2:
+                sender, message = args[0], " ".join(args[1:])
+                conversation.broadcast(sender, message)
+                print(render_history(conversation.history))
+            elif command == "dialogue" and len(args) >= 3:
+                starter, responder, prompt, *rest = args
+                turns = int(rest[0]) if rest else 6
+                coordinator.run_dialogue(starter, responder, prompt, max_turns=turns)
+                print(render_history(conversation.history))
+            elif command == "history":
+                print(render_history(conversation.history))
+            elif command == "clear":
+                conversation.clear_history()
+                print("History cleared.")
+            elif command == "agents":
+                print("Registered agents:", ", ".join(conversation.agent_names))
+            else:
+                print("Unrecognized command. Type 'help' for guidance.")
+        except Exception as exc:  # noqa: BLE001 - bubble readable error to the CLI
+            print(f"Error: {exc}")
+
+
+def _run_send(conversation: Conversation, sender: str, receiver: str, message: str) -> None:
+    conversation.send(sender, receiver, message)
+    print(render_history(conversation.history))
+
+
+def _run_broadcast(conversation: Conversation, sender: str, message: str) -> None:
+    conversation.broadcast(sender, message)
+    print(render_history(conversation.history))
+
+
+def _run_dialogue(
+    conversation: Conversation, starter: str, responder: str, prompt: str, turns: int
+) -> None:
+    coordinator = ConversationCoordinator(conversation)
+    coordinator.run_dialogue(starter, responder, prompt, max_turns=turns)
+    print(render_history(conversation.history))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Text-based UI for the 2agent platform")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    send_parser = subparsers.add_parser("send", help="send a single message between agents")
+    send_parser.add_argument("sender")
+    send_parser.add_argument("receiver")
+    send_parser.add_argument("message", help="message content")
+
+    broadcast_parser = subparsers.add_parser("broadcast", help="broadcast a message to all other agents")
+    broadcast_parser.add_argument("sender")
+    broadcast_parser.add_argument("message")
+
+    dialogue_parser = subparsers.add_parser("dialogue", help="run a multi-turn exchange between two agents")
+    dialogue_parser.add_argument("starter")
+    dialogue_parser.add_argument("responder")
+    dialogue_parser.add_argument("prompt")
+    dialogue_parser.add_argument("--turns", type=int, default=6, dest="turns")
+
+    subparsers.add_parser("repl", help="launch an interactive REPL with a simple text UI")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    conversation = build_default_conversation()
+
+    if args.command == "send":
+        _run_send(conversation, args.sender, args.receiver, args.message)
+    elif args.command == "broadcast":
+        _run_broadcast(conversation, args.sender, args.message)
+    elif args.command == "dialogue":
+        _run_dialogue(conversation, args.starter, args.responder, args.prompt, args.turns)
+    elif args.command == "repl":
+        _start_repl(conversation)
+    else:  # pragma: no cover - argparse ensures command presence
+        parser.error("Unknown command")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/agent_platform/conversation.py
+++ b/agent_platform/conversation.py
@@ -1,0 +1,72 @@
+from typing import Dict, Iterable, List, Optional
+
+from .agent import Agent
+from .messages import Message
+
+
+class Conversation:
+    """Coordinates message exchange between registered agents."""
+
+    def __init__(self):
+        self._agents: Dict[str, Agent] = {}
+        self._history: List[Message] = []
+
+    @property
+    def history(self) -> List[Message]:
+        return list(self._history)
+
+    @property
+    def agent_names(self) -> List[str]:
+        return sorted(self._agents)
+
+    def add_agent(self, agent: Agent) -> None:
+        if agent.name in self._agents:
+            raise ValueError(f"Agent '{agent.name}' is already registered")
+        self._agents[agent.name] = agent
+
+    def remove_agent(self, name: str) -> None:
+        if name not in self._agents:
+            raise ValueError(f"Agent '{name}' is not registered")
+        del self._agents[name]
+
+    def has_agent(self, name: str) -> bool:
+        return name in self._agents
+
+    def _validate_sender_receiver(self, sender: str, receiver: Optional[str]) -> None:
+        if sender not in self._agents:
+            raise ValueError(f"Sender '{sender}' is not registered")
+        if receiver is not None and receiver not in self._agents:
+            raise ValueError(f"Receiver '{receiver}' is not registered")
+
+    def send(self, sender: str, receiver: str, content: str) -> str:
+        self._validate_sender_receiver(sender, receiver)
+
+        outgoing = Message(sender=sender, receiver=receiver, content=content)
+        self._history.append(outgoing)
+
+        reply_text = self._agents[receiver].respond(content, list(self._history))
+        reply = Message(sender=receiver, receiver=sender, content=reply_text)
+        self._history.append(reply)
+        return reply_text
+
+    def broadcast(self, sender: str, content: str) -> List[Message]:
+        """Send the same content to every registered agent except the sender."""
+
+        self._validate_sender_receiver(sender, None)
+        replies: List[Message] = []
+        for receiver in self._agents:
+            if receiver == sender:
+                continue
+            outgoing = Message(sender=sender, receiver=receiver, content=content)
+            self._history.append(outgoing)
+            reply_text = self._agents[receiver].respond(content, list(self._history))
+            reply = Message(sender=receiver, receiver=sender, content=reply_text)
+            self._history.append(reply)
+            replies.append(reply)
+        return replies
+
+    def clear_history(self) -> None:
+        self._history.clear()
+
+    def iter_history(self) -> Iterable[Message]:
+        return iter(self._history)

--- a/agent_platform/coordinator.py
+++ b/agent_platform/coordinator.py
@@ -1,0 +1,36 @@
+from typing import Callable, List, Optional
+
+from .conversation import Conversation
+from .messages import Message
+
+StopCondition = Callable[[Message, List[Message]], bool]
+
+
+class ConversationCoordinator:
+    """Runs longer multi-turn exchanges between two agents."""
+
+    def __init__(self, conversation: Conversation):
+        self.conversation = conversation
+
+    def run_dialogue(
+        self,
+        starter: str,
+        responder: str,
+        initial_prompt: str,
+        max_turns: int = 10,
+        stop_condition: Optional[StopCondition] = None,
+    ) -> List[Message]:
+        if max_turns < 1:
+            raise ValueError("max_turns must be at least 1")
+
+        transcript: List[Message] = []
+        sender, receiver, prompt = starter, responder, initial_prompt
+
+        for _ in range(max_turns):
+            reply_text = self.conversation.send(sender, receiver, prompt)
+            last_message = self.conversation.history[-1]
+            transcript.append(last_message)
+            if stop_condition and stop_condition(last_message, self.conversation.history):
+                break
+            sender, receiver, prompt = receiver, sender, reply_text
+        return transcript

--- a/agent_platform/messages.py
+++ b/agent_platform/messages.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Message:
+    """Represents a message exchanged between agents."""
+
+    sender: str
+    receiver: Optional[str]
+    content: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __str__(self) -> str:
+        receiver_label = self.receiver or "broadcast"
+        return f"[{self.timestamp.isoformat()}] {self.sender} -> {receiver_label}: {self.content}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+import unittest
+
+from agent_platform.cli import build_default_conversation, render_history
+
+
+class CLITests(unittest.TestCase):
+    def test_default_agents_registered(self):
+        conversation = build_default_conversation()
+        for name in {"echo", "uppercase", "reverse", "counter"}:
+            self.assertTrue(conversation.has_agent(name))
+
+    def test_render_history_formats_table(self):
+        conversation = build_default_conversation()
+        conversation.send("echo", "uppercase", "hello")
+        output = render_history(conversation.history)
+        self.assertIn("echo -> uppercase", output)
+        self.assertIn("uppercase -> echo", output)
+        self.assertNotIn("No messages yet", output)
+
+    def test_render_history_handles_empty(self):
+        conversation = build_default_conversation()
+        output = render_history(conversation.history)
+        self.assertIn("No messages yet", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,87 @@
+import unittest
+
+from agent_platform import Agent, Conversation, ConversationCoordinator
+
+
+def echo_handler(prompt, _history):
+    return f"echo: {prompt}"
+
+
+def summarizing_handler(prompt, history):
+    prompts = [message.content for message in history if message.receiver]
+    return f"received {len(prompts)} messages including '{prompt}'"
+
+
+def stop_on_keyword(keyword: str):
+    def _stop(message, _history):
+        return keyword in message.content
+
+    return _stop
+
+
+class ConversationTests(unittest.TestCase):
+    def setUp(self):
+        self.conv = Conversation()
+        self.conv.add_agent(Agent("alpha", echo_handler))
+        self.conv.add_agent(Agent("beta", summarizing_handler))
+
+    def test_round_trip_message(self):
+        reply = self.conv.send("alpha", "beta", "hello")
+        self.assertIn("hello", reply)
+        self.assertEqual(len(self.conv.history), 2)
+        self.assertEqual(self.conv.history[0].sender, "alpha")
+        self.assertEqual(self.conv.history[1].sender, "beta")
+
+    def test_unregistered_agent_raises(self):
+        with self.assertRaises(ValueError):
+            self.conv.send("gamma", "alpha", "who")
+        with self.assertRaises(ValueError):
+            self.conv.send("alpha", "gamma", "who")
+
+    def test_handler_receives_history(self):
+        self.conv.send("alpha", "beta", "first")
+        reply = self.conv.send("alpha", "beta", "second")
+        self.assertIn("3 messages", reply)
+
+    def test_remove_and_readd_agent(self):
+        self.conv.remove_agent("beta")
+        with self.assertRaises(ValueError):
+            self.conv.send("alpha", "beta", "noop")
+        self.conv.add_agent(Agent("beta", summarizing_handler))
+        self.assertTrue(self.conv.has_agent("beta"))
+
+    def test_broadcast_sends_to_all(self):
+        gamma = Agent("gamma", lambda prompt, history: f"got: {prompt} with {len(history)} entries")
+        self.conv.add_agent(gamma)
+        replies = self.conv.broadcast("alpha", "hi team")
+        receiver_names = {message.sender for message in replies}
+        self.assertSetEqual(receiver_names, {"beta", "gamma"})
+        self.assertEqual(len(self.conv.history), 4)
+
+    def test_coordinator_runs_multi_turn_dialogue(self):
+        coordinator = ConversationCoordinator(self.conv)
+        transcript = coordinator.run_dialogue("alpha", "beta", "start", max_turns=3)
+        self.assertGreaterEqual(len(transcript), 1)
+        self.assertEqual(transcript[-1].sender, "beta")
+        self.assertEqual(len(self.conv.history), len(transcript) * 2)
+
+    def test_coordinator_stops_on_condition(self):
+        coordinator = ConversationCoordinator(self.conv)
+        transcript = coordinator.run_dialogue(
+            "alpha",
+            "beta",
+            "stop now",
+            max_turns=5,
+            stop_condition=stop_on_keyword("stop"),
+        )
+        self.assertEqual(len(transcript), 1)
+
+    def test_handler_return_type_enforced(self):
+        bad_agent = Agent("bad", lambda prompt, history: None)
+        self.conv.add_agent(bad_agent)
+        with self.assertRaises(TypeError):
+            self.conv.send("alpha", "bad", "anything")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add broadcast support and agent management utilities to conversations
- introduce a coordinator to run multi-turn alternating dialogues
- extend message metadata and documentation with richer examples

## Testing
- python -m unittest discover -s tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d62d79d88327be22c6d1011efea4)